### PR TITLE
Add opt-in invert_score to parse_be_data for enrichment/activity screens

### DIFF
--- a/beclust3d/lfc3d/preprocess_data.py
+++ b/beclust3d/lfc3d/preprocess_data.py
@@ -29,6 +29,7 @@ def parse_be_data(
     v_score_threshold=3, ### conserv_col
     gene_list=False,
     mutation_priority=None,
+    invert_score=False,
 ):
     """
     Parses raw base editing screen data into per-mutation-type DataFrames for each screen.
@@ -87,6 +88,29 @@ def parse_be_data(
         list of per-edit categories (e.g. 'Silent;Missense;'). If None, mut_col
         values are used as-is, assuming they are already single categories.
 
+    invert_score : bool, optional (default=False)
+        If True, negate the numeric value column (val_col) of every screen
+        BEFORE any per-mutation parsing/aggregation, so that the sign of the
+        resulting neg/pos channels reflects the intended biology.
+
+        BE3D assumes a DROPOUT sign convention: loss-of-function (LOF) is
+        expected to produce a NEGATIVE score, so LOF hits land in the negative
+        channel and downstream interpretation treats negative as deleterious.
+        Two classes of screen have the OPPOSITE polarity and should set
+        invert_score=True:
+
+          - Activity-reporter screens (e.g. a methylation->fluorescence
+            reporter) where LOF gives a HIGH / POSITIVE signal.
+          - Drug-resistance / positive-selection ENRICHMENT screens where the
+            hit is enrichment, i.e. a POSITIVE score.
+
+        Fed raw (invert_score=False), these screens silently flip the biology:
+        LOF hits fall into the positive channel. Because the built-in QA uses
+        two-sided tests (Mann-Whitney U / KS), it is unaffected by the sign and
+        will still "pass", hiding the error. Setting invert_score=True fixes the
+        polarity so LOF hits carry a negative score as the rest of the pipeline
+        expects. Default (False) leaves all values unchanged.
+
     Returns
     -------
     mut_dfs : dict
@@ -128,6 +152,12 @@ def parse_be_data(
             conserv_list = [str(x) for x in conserv_df[conserv_df['v_score']>=v_score_threshold][conserv_col].tolist()]
         # NARROW DOWN TO INPUT_GENE #
         df_gene = screen_df.loc[screen_df[gene_col] == input_gene, ]
+        # INVERT SCORE SIGN FOR ENRICHMENT / ACTIVITY SCREENS (OPT-IN) #
+        # Done BEFORE any per-mutation parsing so neg/pos channels carry the
+        # intended biology. QA is two-sided, so it is unaffected by the sign.
+        if invert_score:
+            df_gene = df_gene.copy()
+            df_gene[val_col] = -df_gene[val_col]
         if mutation_priority:
             df_gene = df_gene.copy()
             df_gene[mut_col] = df_gene[mut_col].apply(

--- a/examples/be3d_local.py
+++ b/examples/be3d_local.py
@@ -569,6 +569,7 @@ def main(**kwargs):
 	atom_level_naa=kwargs['atom_level_naa']
 	muscle_path=kwargs['muscle_path']
 	mutation_priority=kwargs['mutation_priority']
+	invert_score=kwargs.get('invert_score', False)
 
 	if user_pdb:
 		structureid = f'PDB-{input_uniprot}'
@@ -708,7 +709,8 @@ def main(**kwargs):
 		conserv_dfs = conserv_dfs,
 		conserv_col='alternative_res_pos',
 		gene_list=gene_list,
-		v_score_threshold=v_score_threshold
+		v_score_threshold=v_score_threshold,
+		invert_score=invert_score,
 		)
 
 	# For All
@@ -1547,6 +1549,8 @@ if __name__ == '__main__':
 	muscle_path = config.get('muscle_path', 'muscle')
 	mutation_priority = config.get('mutation_priority') # optional; most-to-least-deleterious order for collapsing
 	                                                      # delimiter-joined multi-category mut_col values (e.g. 'Silent;Missense;')
+	invert_score = config.get('invert_score', False)      # optional; negate val_col for enrichment/activity screens where
+	                                                      # LOF is a POSITIVE score (default False keeps dropout convention)
 
 	# KWARGS SHARED ACROSS EVERY main() CALL, REGARDLESS OF MODE #
 	common_kwargs = dict(
@@ -1558,7 +1562,7 @@ if __name__ == '__main__':
 		alt_screen_start=alt_screen_start, v_score_threshold=v_score_threshold,
 		function_for_meta=function_for_meta, qa_passed_only=qa_passed_only, qa_only=qa_only, qa_controls=qa_controls, qa_cases=qa_cases,
 		priority_on_alternative=priority_on_alternative, config_yaml=config_yaml, atom_level_naa=atom_level_naa, muscle_path=muscle_path,
-		mutation_priority=mutation_priority,
+		mutation_priority=mutation_priority, invert_score=invert_score,
 	)
 
 	if mode == 'monomer':

--- a/examples/yaml/cross_species_MORC2.yaml
+++ b/examples/yaml/cross_species_MORC2.yaml
@@ -18,6 +18,10 @@ clustering_radius: 6.0
 function_for_lfc: mean
 function_for_lfc3d: mean
 function_for_meta: SUM
+# invert_score: negate val_col for enrichment / activity-reporter screens where
+# loss-of-function is a POSITIVE score. Leave false (default) for standard
+# dropout screens where LOF is negative. QA is two-sided, so it is unaffected.
+invert_score: false
 database:
   mut_col: Mutation_type
   val_col: sgRNA_score

--- a/tests/test_invert_score.py
+++ b/tests/test_invert_score.py
@@ -1,0 +1,128 @@
+"""
+Tests for the opt-in `invert_score` parameter of parse_be_data.
+
+`invert_score=True` negates the numeric value column (val_col) of every screen
+BEFORE per-mutation parsing/aggregation, so that enrichment / activity-reporter
+screens (where loss-of-function is a POSITIVE score) end up with the same
+dropout sign convention (LOF -> negative) the rest of the pipeline assumes.
+
+These tests are fully self-contained and offline: they build a small synthetic
+screen DataFrame and only exercise parse_be_data (no FASTA/PDB/structure step).
+"""
+
+import pandas as pd
+import pytest
+
+from beclust3d.lfc3d.preprocess_data import parse_be_data
+
+
+GENE = "TESTGENE"
+SCREEN = "screenA"
+
+
+def _synthetic_screen():
+    """A tiny screen with one guide per mutation category.
+
+    The Nonsense guide is a POSITIVE-scored 'hit' (as in an enrichment /
+    activity-reporter screen), where LOF shows up as a positive score.
+    """
+    return pd.DataFrame(
+        {
+            "Mutation category": [
+                "Nonsense",
+                "Missense",
+                "Silent",
+                "No Mutation",
+            ],
+            "Amino Acid Edits": [
+                "Q100*",   # nonsense (LOF)
+                "A50T",    # missense
+                "G30G",    # silent
+                "",        # no mutation
+            ],
+            "Target Gene Symbol": [GENE, GENE, GENE, GENE],
+            "logFC": [2.5, -1.0, 0.3, 0.1],
+        }
+    )
+
+
+def _lfc_series(subset):
+    """Return the LFC values of a parse_be_data output as a plain list.
+
+    parse_be_data returns a DataFrame (with an 'LFC' column) for most
+    categories and a bare Series for 'No Mutation'.
+    """
+    if isinstance(subset, pd.Series):
+        return list(subset.values)
+    return list(subset["LFC"].values)
+
+
+def _run(tmp_path, invert):
+    df = _synthetic_screen()
+    return parse_be_data(
+        workdir=str(tmp_path),
+        input_dfs=[df],
+        input_gene=GENE,
+        screen_names=[SCREEN],
+        conserv_dfs=[None],
+        gene_list=[GENE],
+        invert_score=invert,
+    )
+
+
+def test_values_exactly_negated(tmp_path):
+    """(a) Every per-mutation LFC value is exactly negated between runs."""
+    out_false = _run(tmp_path / "noinv", invert=False)
+    out_true = _run(tmp_path / "inv", invert=True)
+
+    muts_false = out_false[SCREEN]
+    muts_true = out_true[SCREEN]
+    assert set(muts_false.keys()) == set(muts_true.keys())
+
+    # There must be at least one non-empty category to make the test meaningful.
+    seen_any = False
+    for mut in muts_false:
+        vals_false = _lfc_series(muts_false[mut])
+        vals_true = _lfc_series(muts_true[mut])
+        assert len(vals_false) == len(vals_true)
+        for a, b in zip(vals_false, vals_true):
+            if pd.isna(a) or pd.isna(b):
+                assert pd.isna(a) and pd.isna(b)
+                continue
+            seen_any = True
+            assert a == pytest.approx(-b)
+    assert seen_any, "expected at least one numeric LFC value to compare"
+
+
+def test_positive_hit_becomes_negative(tmp_path):
+    """(b) A POSITIVE-scored nonsense hit (invert=False) lands in the
+    LOF / negative direction when invert=True."""
+    out_false = _run(tmp_path / "noinv", invert=False)
+    out_true = _run(tmp_path / "inv", invert=True)
+
+    non_false = _lfc_series(out_false[SCREEN]["Nonsense"])
+    non_true = _lfc_series(out_true[SCREEN]["Nonsense"])
+
+    assert len(non_false) == 1 and len(non_true) == 1
+    assert non_false[0] > 0          # positive score without inversion
+    assert non_true[0] < 0           # flipped to the LOF / neg direction
+    assert non_true[0] == pytest.approx(-non_false[0])
+
+
+def test_default_is_unchanged(tmp_path):
+    """Default (invert_score omitted) matches invert_score=False byte-for-byte."""
+    df = _synthetic_screen()
+    out_default = parse_be_data(
+        workdir=str(tmp_path / "default"),
+        input_dfs=[df],
+        input_gene=GENE,
+        screen_names=[SCREEN],
+        conserv_dfs=[None],
+        gene_list=[GENE],
+    )
+    out_false = _run(tmp_path / "false", invert=False)
+
+    for mut in out_default[SCREEN]:
+        assert _lfc_series(out_default[SCREEN][mut]) == _lfc_series(
+            out_false[SCREEN][mut]
+        )


### PR DESCRIPTION
## Problem
BE3D bakes in a **dropout** sign convention: loss-of-function (LOF) is expected to produce a **negative** score, so the neg/pos channels and downstream interpretation assume LOF hits are negative. Two common screen designs are the opposite polarity:

- **Activity-reporter screens** (e.g. a methylation→fluorescence reporter) where LOF gives a **high / positive** signal.
- **Drug-resistance / positive-selection ENRICHMENT screens** where the hit is enrichment, i.e. a **positive** score.

Fed raw, the biology silently flips (LOF hits land in the positive channel). Because the built-in QA uses **two-sided** tests (Mann–Whitney U / KS), it is insensitive to sign and still "passes", hiding the error. Users currently have to hand-negate the score column.

## What changed
- Added an explicit, opt-in `invert_score: bool = False` parameter to `parse_be_data` in `beclust3d/lfc3d/preprocess_data.py`. When `True`, the numeric value column (`val_col`) of every screen is negated **before** any per-mutation parsing/aggregation, so the resulting neg/pos channels carry the intended biology.
- Documented dropout vs enrichment/activity conventions in the docstring, and noted that QA is two-sided and therefore unaffected.
- Threaded the flag through `examples/be3d_local.py` (config → `common_kwargs` → `main` → `parse_be_data`) and added an `invert_score` key to `examples/yaml/cross_species_MORC2.yaml` (default `false`).
- Added `tests/test_invert_score.py`.

## How tested
Self-contained, offline tests build a small synthetic screen (Missense/Silent/Nonsense/No Mutation guides with an amino-acid-edits column and known scores, including a positive-scored nonsense "hit") and call `parse_be_data` twice into temp workdirs. They assert:
- (a) every per-mutation LFC value is exactly negated between `invert_score=False` and `True`;
- (b) a nonsense hit that is **positive** with `invert_score=False` becomes **negative** with `invert_score=True` (lands in the LOF/neg direction);
- default behavior (flag omitted) matches `invert_score=False`.

```
3 passed, 8 warnings in 2.19s
```
(The 8 warnings are pre-existing and unrelated: `\d` escape-sequence warnings and a "Splice Site not in Dataframe" notice.)

## Backward compatibility
Default `invert_score=False` leaves all values unchanged — behavior is byte-identical to before. The math is otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)