### PR TITLE
Add base-editing reachability report

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,20 @@ If MUSCLE or CLUSTAL cannot be run locally, the pipeline queries the MUSCLE API,
 
 Another option to skip MUSCLE and CLUSTAL is for users to run alignment on their own in a CLUSTAL format, and provide the ```sequence.align``` alignment file into the pipeline which is one of the optional inputs. 
 
+### Base-editing reachability
+
+A base editor (CBE/ABE) can only install a subset of amino-acid substitutions, so many validated functional residues are simply not reachable by a tiling screen (e.g. EGFR T790M/C797S/L858R, BRAF V600E, PIK3CA H1047R, AKT1 E17K require transversions or indels no base editor makes). A residue with no editing guide can never be scored as a hotspot, so an apparent BE3D "miss" is often the assay's coverage limit rather than an algorithmic failure.
+
+`reachability_report` is an additive reporting utility (it does not change LFC3D scoring or clustering) that takes the per-residue missense edits table BE3D already builds (the ```*_protein_edits.tsv``` from ```prioritize_by_sequence```) and reports which residues were reachable, overall coverage, and — optionally — whether a supplied list of known functional/hotspot residues was editable at all:
+
+```python
+from beclust3d import reachability_report
+summary = reachability_report(df_protein, total_residues=1210,
+                              target_residues=[790, 797, 858],  # EGFR hotspots
+                              out_tsv="EGFR_reachability.tsv")
+# summary['coverage'], summary['targets']['unreachable']  -> uneditable hotspots
+```
+
 
 
 ## License

--- a/beclust3d/__init__.py
+++ b/beclust3d/__init__.py
@@ -9,6 +9,7 @@ from .lfc3d.preprocess_data_plot import plot_rawdata
 
 from .lfc3d.prioritize_sequence import prioritize_by_sequence
 from .lfc3d.prioritize_sequence_plot import plot_screendata_sequence
+from .lfc3d.reachability import reachability_report
 from .lfc3d.randomize_sequence import randomize_sequence
 
 from .lfc3d.calculate_lfc3d import calculate_lfc3d
@@ -34,9 +35,10 @@ __all__ = [
     "randomize_data", 
     "plot_rawdata", 
 
-    "prioritize_by_sequence", 
-    "plot_screendata_sequence", 
-    "randomize_sequence", 
+    "prioritize_by_sequence",
+    "plot_screendata_sequence",
+    "reachability_report",
+    "randomize_sequence",
 
     "calculate_lfc3d", 
     "average_split_meta", "bin_meta", "znorm_meta", 

--- a/beclust3d/lfc3d/reachability.py
+++ b/beclust3d/lfc3d/reachability.py
@@ -1,0 +1,182 @@
+"""
+File: reachability.py
+Author: Amit Shenoy
+Date: 2026-08-29
+Description:
+    Base-editing reachability report.
+
+    A base editor (CBE / ABE) can only install a subset of amino-acid
+    substitutions, so many validated functional residues are simply NOT
+    REACHABLE by a tiling screen (e.g. EGFR T790M / C797S / L858R,
+    BRAF V600E, PIK3CA H1047R, AKT1 E17K, DNMT3A R882H all require
+    transversions or indels that no base editor makes). A residue with no
+    editing guide can never be scored as a hotspot, so BE3D "misses" are
+    frequently the assay's coverage limit rather than an algorithmic failure.
+
+    This module is an additive, off-critical-path reporting utility: it does
+    NOT change LFC3D scoring or clustering. Given the per-residue missense
+    edits table BE3D already builds (the `*_protein_edits.tsv` produced by
+    `prioritize_by_sequence`), it reports which residues actually received a
+    missense edit ("reachable") and, optionally, whether a user-supplied set
+    of known functional / hotspot residues was reachable at all.
+"""
+
+import os
+from pathlib import Path
+
+import pandas as pd
+
+
+def _count_edits(value):
+    """Count the number of distinct edits encoded in an `all_*_edits` cell.
+
+    BE3D stores per-residue edits as a ';'-joined string (e.g. 'G12C;G12D'),
+    or the sentinel '-' / empty / NaN when no edit maps to that residue.
+    Returns an int (0 when no edit is present).
+    """
+    if value is None:
+        return 0
+    # NaN check (floats) without importing numpy
+    if isinstance(value, float) and pd.isna(value):
+        return 0
+    text = str(value).strip()
+    if text == '' or text == '-':
+        return 0
+    return len([tok for tok in text.split(';') if tok.strip() not in ('', '-')])
+
+
+def reachability_report(
+    df_protein,
+    total_residues=None,
+    target_residues=None,
+    out_tsv=None,
+    mutation_type='Missense',
+    pos_col='unipos',
+    res_col='unires',
+    edits_col=None,
+):
+    """Compute a base-editing reachability report for a screened protein.
+
+    A residue is "reachable" if the screen installed at least one missense
+    edit at it (i.e. the per-residue edits cell is not the '-' sentinel).
+    Unreachable residues can never become hotspots, so this report lets a
+    user distinguish an editor-coverage gap from a true biological negative.
+
+    Parameters
+    ----------
+    df_protein : pd.DataFrame
+        Per-residue missense edits table as produced by
+        `prioritize_by_sequence` (the `*_protein_edits.tsv`). Must contain a
+        residue-position column (`pos_col`) and an edits column
+        (`edits_col`, default `all_{mutation_type}_edits`). A residue name
+        column (`res_col`) is used if present.
+    total_residues : int, optional
+        Total number of residues in the protein (its sequence/structure span).
+        Coverage is computed against this. Defaults to `len(df_protein)`.
+    target_residues : list of int, optional
+        Positions of known functional / hotspot residues to check explicitly
+        (e.g. clinical driver or resistance residues). The report states how
+        many were reachable vs unreachable and lists the unreachable ones.
+    out_tsv : str or Path, optional
+        Path to write the per-residue TSV. If None, no file is written.
+    mutation_type : str, optional (default 'Missense')
+        Mutation type whose edits define reachability. Used to build the
+        default `edits_col` name (`all_{mutation_type}_edits`).
+    pos_col : str, optional (default 'unipos')
+        Column holding the residue position.
+    res_col : str, optional (default 'unires')
+        Column holding the residue identity (one-letter). Optional.
+    edits_col : str, optional
+        Column holding the ';'-joined edits. Defaults to
+        `all_{mutation_type}_edits`.
+
+    Returns
+    -------
+    dict
+        Summary dictionary with keys:
+        `total_residues`, `n_reachable`, `n_unreachable`, `coverage`
+        (fraction in [0, 1]), `reachable_positions` (sorted list),
+        `unreachable_positions` (sorted list), `mutation_type`, `out_tsv`,
+        and, when `target_residues` is given, a nested `targets` dict with
+        `n_targets`, `n_reachable`, `n_unreachable`, `reachable`,
+        `unreachable` (sorted lists of positions).
+    """
+    if edits_col is None:
+        edits_col = f'all_{mutation_type}_edits'
+    if pos_col not in df_protein.columns:
+        raise KeyError(f"Position column '{pos_col}' not found in df_protein.")
+    if edits_col not in df_protein.columns:
+        raise KeyError(
+            f"Edits column '{edits_col}' not found in df_protein. "
+            f"Pass edits_col=... or set mutation_type to match your table."
+        )
+
+    rows = []
+    reachable_positions = []
+    for _, row in df_protein.iterrows():
+        unipos = int(row[pos_col])
+        unires = row[res_col] if res_col in df_protein.columns else '-'
+        n_guides = _count_edits(row[edits_col])
+        reachable = n_guides > 0
+        if reachable:
+            reachable_positions.append(unipos)
+        rows.append({
+            'unipos': unipos,
+            'unires': unires,
+            'n_missense_guides': n_guides,
+            'reachable': reachable,
+        })
+
+    df_report = pd.DataFrame(rows, columns=['unipos', 'unires',
+                                            'n_missense_guides', 'reachable'])
+
+    reachable_positions = sorted(set(reachable_positions))
+    reachable_set = set(reachable_positions)
+
+    if total_residues is None:
+        total_residues = len(df_protein)
+    total_residues = int(total_residues)
+    n_reachable = len(reachable_set)
+    n_unreachable = max(total_residues - n_reachable, 0)
+
+    # Unreachable = every position in [1..total] with no missense edit, plus
+    # any positions present in the table but unreachable (kept consistent via
+    # the report rows). Report unreachable positions from the full span.
+    all_positions = set(range(1, total_residues + 1))
+    # include out-of-span table positions in the reachable set accounting only
+    all_positions |= set(int(p) for p in df_report['unipos'].tolist())
+    unreachable_positions = sorted(all_positions - reachable_set)
+
+    coverage = (n_reachable / total_residues) if total_residues > 0 else 0.0
+
+    summary = {
+        'mutation_type': mutation_type,
+        'total_residues': total_residues,
+        'n_reachable': n_reachable,
+        'n_unreachable': n_unreachable,
+        'coverage': coverage,
+        'reachable_positions': reachable_positions,
+        'unreachable_positions': unreachable_positions,
+        'out_tsv': None,
+    }
+
+    if target_residues is not None:
+        targets = [int(t) for t in target_residues]
+        t_reachable = sorted([t for t in targets if t in reachable_set])
+        t_unreachable = sorted([t for t in targets if t not in reachable_set])
+        summary['targets'] = {
+            'n_targets': len(targets),
+            'n_reachable': len(t_reachable),
+            'n_unreachable': len(t_unreachable),
+            'reachable': t_reachable,
+            'unreachable': t_unreachable,
+        }
+
+    if out_tsv is not None:
+        out_path = Path(out_tsv)
+        if out_path.parent and not os.path.exists(out_path.parent):
+            os.makedirs(out_path.parent, exist_ok=True)
+        df_report.to_csv(out_path, sep='\t', index=False)
+        summary['out_tsv'] = str(out_path)
+
+    return summary

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -1,0 +1,81 @@
+"""
+Self-contained, offline tests for beclust3d.reachability_report.
+
+Builds a small synthetic per-residue missense edits table (residues 1..20,
+missense edits present only at {3, 4, 7, 12}) and checks the reachability
+accounting, target-residue reporting, and the written TSV. No network or
+real structures are required.
+"""
+
+import pandas as pd
+
+from beclust3d.lfc3d.reachability import reachability_report
+
+
+AA = "ACDEFGHIKLMNPQRSTVWY"  # 20 residues, one per position 1..20
+
+
+def _make_table(edited_positions):
+    """Per-residue edits table in the BE3D `*_protein_edits.tsv` shape."""
+    rows = []
+    edited = set(edited_positions)
+    for pos in range(1, 21):
+        unires = AA[pos - 1]
+        if pos in edited:
+            # two distinct missense edits at this residue
+            edits = f"{unires}{pos}A;{unires}{pos}G"
+        else:
+            edits = "-"  # BE3D sentinel for "no edit maps here"
+        rows.append({"unipos": pos, "unires": unires,
+                     "all_Missense_edits": edits})
+    return pd.DataFrame(rows)
+
+
+def test_reachability_report(tmp_path):
+    df = _make_table({3, 4, 7, 12})
+    out_tsv = tmp_path / "reachability.tsv"
+
+    summary = reachability_report(
+        df,
+        total_residues=20,
+        target_residues=[4, 5, 12, 18],
+        out_tsv=out_tsv,
+    )
+
+    # Reachable set is exactly the edited positions
+    assert set(summary["reachable_positions"]) == {3, 4, 7, 12}
+    assert summary["n_reachable"] == 4
+    assert summary["n_unreachable"] == 16
+    assert summary["total_residues"] == 20
+    assert summary["coverage"] == 4 / 20
+
+    # Target-residue accounting
+    targets = summary["targets"]
+    assert targets["n_targets"] == 4
+    assert targets["reachable"] == [4, 12]
+    assert targets["unreachable"] == [5, 18]
+    assert targets["n_reachable"] == 2
+    assert targets["n_unreachable"] == 2
+
+    # TSV written with the expected columns and per-residue reachability
+    assert out_tsv.exists()
+    df_out = pd.read_csv(out_tsv, sep="\t")
+    assert list(df_out.columns) == [
+        "unipos", "unires", "n_missense_guides", "reachable",
+    ]
+    assert len(df_out) == 20
+    reached = set(df_out.loc[df_out["reachable"], "unipos"])
+    assert reached == {3, 4, 7, 12}
+    # each edited residue carries its two synthetic guides
+    assert df_out.loc[df_out["unipos"] == 4, "n_missense_guides"].iloc[0] == 2
+    assert df_out.loc[df_out["unipos"] == 5, "n_missense_guides"].iloc[0] == 0
+
+
+def test_reachability_defaults_total_and_no_targets(tmp_path):
+    df = _make_table({3, 4, 7, 12})
+    summary = reachability_report(df)  # no total, no targets, no TSV
+    assert summary["total_residues"] == 20  # defaults to len(df)
+    assert summary["n_reachable"] == 4
+    assert summary["coverage"] == 4 / 20
+    assert "targets" not in summary
+    assert summary["out_tsv"] is None


### PR DESCRIPTION
## Problem

A base editor (CBE/ABE) can only install a subset of amino-acid substitutions, so many validated functional residues are simply **not reachable** by a tiling screen. Across a 15-screen benchmark this was the single biggest interpretability gap: EGFR T790M/C797S/L858R, BRAF V600E, PIK3CA H1047R, AKT1 E17K, DNMT3A R882H and many others require transversions or indels that no base editor makes (on EGFR ~18/25 and on BRAF 12/15 curated clinical residues receive no signal for this reason). A residue with no editing guide can never be scored as a hotspot, so a BE3D "miss" is frequently the assays coverage limit rather than an algorithmic failure. BE3D previously gave users no visibility into this, making intrinsic base-editor gaps easy to misread as false negatives (and even wrong-substitution traps like AKT1 E17K -> E17G).

## What changed

- New `reachability_report(...)` in `beclust3d/lfc3d/reachability.py`, exported from `beclust3d/__init__.py`.
- Input is the per-residue missense edits table BE3D already builds (the `*_protein_edits.tsv` produced by `prioritize_by_sequence`), plus the total residue span.
- Output:
  - **Per-residue** TSV with `unipos`, `unires`, `n_missense_guides`, `reachable` (bool).
  - **Summary dict**: total residues, # reachable, # unreachable, % coverage, and reachable/unreachable position lists.
  - **Optional** `target_residues` (known functional/hotspot positions): reports how many were reachable vs not and lists the unreachable ones, so a user can immediately see "these known sites were uneditable, so absence of signal is expected."
- README note with a one-line usage example.

Additive and **off the critical path**: this is a reporting utility only. LFC3D scoring and clustering are untouched.

## How tested

`tests/test_reachability.py` (self-contained, offline; no network or real structures). Builds a synthetic per-residue edits table (residues 1..20, missense edits at {3,4,7,12}), calls `reachability_report(total_residues=20, target_residues=[4,5,12,18])`, and asserts: reachable set == {3,4,7,12}; coverage == 4/20; targets 4 and 12 reachable, 5 and 18 not; summary counts correct; and the TSV is written with the expected columns.

```
$ pytest tests/test_reachability.py -q
..                                                                       [100%]
2 passed, 2 warnings in 2.10s
```
(The 2 warnings are pre-existing `SyntaxWarning`s from `preprocess_data.py`, unrelated to this change.)

## Backward compatibility

Fully backward compatible. Only adds a new function and one export; no existing signatures, outputs, or behavior change. Writing a TSV is opt-in (`out_tsv` defaults to `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)