### PR TITLE
Add Benjamini-Hochberg FDR q-values alongside raw p-values

### DIFF
--- a/beclust3d/aggregate/aggregate_helpers.py
+++ b/beclust3d/aggregate/aggregate_helpers.py
@@ -14,6 +14,74 @@ import glob, os
 
 # HELPER FUNCTIONS #
 
+def benjamini_hochberg(
+    pvals
+):
+    """
+    Benjamini-Hochberg (BH) step-up false discovery rate (FDR) q-values.
+
+    BE3D calls per-residue significance directly on the raw p-values
+    (e.g. p<0.05/0.01/0.001) with no correction for the many residues tested
+    simultaneously. In practice the fraction of residues flagged at raw p<0.05
+    (the "base rate") has ranged from ~7% to ~50% across targets, so the raw
+    p<0.05 flag over-calls and forces users to rank hits by hand. The standard
+    multiple-testing fix is to report BH/FDR q-values alongside the raw p-values
+    and threshold on those instead. A q-value threshold of q<0.1 (i.e. accepting
+    an expected 10% false discovery rate) is the recommended, multiplicity-aware
+    way to call significant residues.
+
+    The q-value for a p-value p_(i) (with p-values sorted ascending, rank i,
+    m tested) is::
+
+        q_(i) = min_{k >= i} ( m / k * p_(k) )
+
+    capped at 1.0, which makes the sorted q-values monotonically non-decreasing
+    and guarantees q >= p for every entry.
+
+    Parameters
+    ----------
+    pvals : array-like
+        Raw p-values. May contain NaN or the string '-' (BE3D's missing-value
+        marker); those entries are ignored when computing the FDR correction and
+        are returned as NaN in the same position. Order is preserved and ties are
+        handled with a stable sort.
+
+    Returns
+    -------
+    numpy.ndarray
+        Float array of BH q-values, same length and order as ``pvals``, with NaN
+        wherever the input was NaN / '-'.
+    """
+    # COERCE TO FLOAT, TREATING '-' AND None AS MISSING (NaN) #
+    arr = np.array(
+        [np.nan if (v is None or (isinstance(v, str) and v == '-')) else v
+         for v in pvals],
+        dtype=float,
+    )
+
+    q = np.full(arr.shape, np.nan, dtype=float)
+    mask = ~np.isnan(arr)
+    p = arr[mask]
+    m = p.size
+    if m == 0:
+        return q
+
+    # STEP-UP BH: SORT ASCENDING (STABLE), SCALE BY m / rank #
+    order = np.argsort(p, kind='stable')
+    ranked = p[order]
+    ranks = np.arange(1, m + 1)
+    q_sorted = ranked * m / ranks
+
+    # ENFORCE MONOTONICITY (CUMULATIVE MIN FROM THE LARGEST P) AND CAP AT 1 #
+    q_sorted = np.minimum.accumulate(q_sorted[::-1])[::-1]
+    q_sorted = np.minimum(q_sorted, 1.0)
+
+    # UNSORT BACK TO ORIGINAL ORDER, THEN SCATTER INTO NON-MISSING SLOTS #
+    q_valid = np.empty(m, dtype=float)
+    q_valid[order] = q_sorted
+    q[mask] = q_valid
+    return q
+
 def sum_dash(
     values
 ): 

--- a/beclust3d/aggregate/metaaggregate.py
+++ b/beclust3d/aggregate/metaaggregate.py
@@ -268,6 +268,17 @@ def znorm_meta(
     -------
     df_meta_Z : pd.DataFrame
         DataFrame containing z-scores, p-values, and significance labels per residue at each threshold in pthrs.
+        Also includes Benjamini-Hochberg FDR q-value columns (``{aggr_func}_{score_type}_neg_q`` and
+        ``{aggr_func}_{score_type}_pos_q``) computed across all residues per direction.
+
+    Notes
+    -----
+    The raw p<0.05/0.01/0.001 significance labels apply no correction for the many residues
+    tested simultaneously, so the fraction of residues flagged ("base rate") can be high
+    (~7%-50% across targets in our benchmarking) and raw p<0.05 tends to over-call. The added
+    q-value columns are Benjamini-Hochberg FDR values; thresholding on q (e.g. q<0.1) is the
+    recommended multiple-testing-aware way to call significant residues. All existing p-value
+    and significance columns are unchanged.
     """
 
     # THE META-AGGREGATED RESULTS ARE Z SCORED TO THE WHOLE SET OF RANDOMIZED CONTROLS #
@@ -347,7 +358,18 @@ def znorm_meta(
                 result_data[f'{header_main}_{sign}_{pthr_str}_p'].append(signal_p)
                 result_data[f'{header_main}_{sign}_{pthr_str}_psig'].append(signal_plabel)
 
+    # ADD BENJAMINI-HOCHBERG FDR Q-VALUES ALONGSIDE THE RAW P-VALUES #
+    # The raw p-values do not depend on the p-value threshold, so a single
+    # q-value column per direction accompanies the (threshold-indexed) p
+    # columns. Recommended multiplicity-aware call: q<0.1 (see helper docs);
+    # raw p<0.05 over-calls because base rates can be high. #
+    q_data = {}
+    for sign in ['neg', 'pos']:
+        pvals = result_data[f'{header_main}_{sign}_{pthrs_str[0]}_p']
+        q_data[f'{header_main}_{sign}_q'] = benjamini_hochberg(pvals)
+
     df_temp = pd.DataFrame(result_data).replace(0,'-')
+    df_temp = pd.concat([df_temp, pd.DataFrame(q_data)], axis=1)
     df_meta_Z = pd.concat([df_meta_Z, df_temp], axis=1)
 
     # SAVE #

--- a/beclust3d/aggregate/nonaggregate.py
+++ b/beclust3d/aggregate/nonaggregate.py
@@ -213,6 +213,17 @@ def znorm_score(
     -------
     df_z : pd.DataFrame
         DataFrame containing z-scores, p-values, and significance labels per residue at each threshold in pthrs.
+        Also includes Benjamini-Hochberg FDR q-value columns (``{screen}_{score_type}_neg_q`` and
+        ``{screen}_{score_type}_pos_q``) computed across all residues per direction.
+
+    Notes
+    -----
+    The raw p<0.05/0.01/0.001 significance labels apply no correction for the many residues
+    tested simultaneously, so the fraction of residues flagged ("base rate") can be high
+    (~7%-50% across targets in our benchmarking) and raw p<0.05 tends to over-call. The added
+    q-value columns are Benjamini-Hochberg FDR values; thresholding on q (e.g. q<0.1) is the
+    recommended multiple-testing-aware way to call significant residues. All existing p-value
+    and significance columns are unchanged.
     """
     # EACH SCREEN IS Z SCORED TO ITS OWN SET OF RANDOMIZED CONTROLS #
     # ASSUMED NEG AND POS FOR EACH #
@@ -294,6 +305,15 @@ def znorm_score(
                     result_data[f'{header_main}_{sign}_{pthr_str}_z'].append(signal_z)
                     result_data[f'{header_main}_{sign}_{pthr_str}_p'].append(signal_p)
                     result_data[f'{header_main}_{sign}_{pthr_str}_psig'].append(signal_plabel)
+
+        # ADD BENJAMINI-HOCHBERG FDR Q-VALUES ALONGSIDE THE RAW P-VALUES #
+        # The raw p-values do not depend on the p-value threshold, so a single
+        # q-value column per direction accompanies the (threshold-indexed) p
+        # columns. Recommended multiplicity-aware call: q<0.1 (see helper docs);
+        # raw p<0.05 over-calls because base rates can be high. #
+        for sign in ['neg', 'pos']:
+            pvals = result_data[f'{header_main}_{sign}_{pthrs_str[0]}_p']
+            result_data[f'{header_main}_{sign}_q'] = benjamini_hochberg(pvals)
 
         df_temp = pd.DataFrame(result_data)
         df_z = pd.concat([df_z, df_temp], axis=1)

--- a/tests/test_fdr.py
+++ b/tests/test_fdr.py
@@ -1,0 +1,115 @@
+"""
+Tests for the Benjamini-Hochberg FDR q-value helper and the companion
+q-value columns added to znorm_score / znorm_meta.
+
+Run directly (this repo has no pytest config yet):
+    PYTHONPATH=<repo> python -m pytest tests/test_fdr.py -q
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from beclust3d.aggregate.aggregate_helpers import benjamini_hochberg
+
+
+# ---- unit tests for benjamini_hochberg ------------------------------------
+
+def test_uniform_scaling_example():
+    # p = k/100 for k=1..5, m=5 -> every q_(k) = p_(k)*5/k = 0.05
+    pvals = [0.01, 0.02, 0.03, 0.04, 0.05]
+    q = benjamini_hochberg(pvals)
+    assert np.allclose(q, [0.05, 0.05, 0.05, 0.05, 0.05])
+
+
+def test_mixed_example_handcomputed():
+    # p in an intentionally out-of-order arrangement.
+    # sorted: 0.005(r1) 0.02(r2) 0.04(r3) 0.20(r4) 0.60(r5), m=5
+    # raw q: 0.025, 0.05, 0.0666667, 0.25, 0.60 (already monotone)
+    pvals = [0.005, 0.02, 0.20, 0.04, 0.60]
+    expected = [0.025, 0.05, 0.25, 0.0666666667, 0.60]
+    q = benjamini_hochberg(pvals)
+    assert np.allclose(q, expected)
+
+
+def test_monotonicity_of_sorted_q_and_q_ge_p():
+    rng = np.random.default_rng(0)
+    pvals = rng.uniform(0, 1, size=200)
+    q = benjamini_hochberg(pvals)
+    # q >= p everywhere
+    assert np.all(q >= pvals - 1e-12)
+    # sorted-by-p q-values are non-decreasing
+    order = np.argsort(pvals, kind='stable')
+    q_sorted = q[order]
+    assert np.all(np.diff(q_sorted) >= -1e-12)
+    # capped at 1
+    assert np.all(q <= 1.0 + 1e-12)
+
+
+def test_nan_and_dash_passthrough():
+    pvals = [0.01, '-', 0.02, np.nan, 0.03]
+    q = benjamini_hochberg(pvals)
+    # only 3 valid entries, all scale to 0.03
+    assert np.isnan(q[1]) and np.isnan(q[3])
+    assert np.allclose([q[0], q[2], q[4]], [0.03, 0.03, 0.03])
+
+
+def test_all_missing_returns_all_nan():
+    q = benjamini_hochberg(['-', np.nan, None])
+    assert q.shape == (3,)
+    assert np.all(np.isnan(q))
+
+
+def test_single_value_equals_itself():
+    q = benjamini_hochberg([0.037])
+    assert np.allclose(q, [0.037])
+
+
+def test_accepts_numpy_and_series():
+    pvals = [0.01, 0.02, 0.03, 0.04, 0.05]
+    q_list = benjamini_hochberg(pvals)
+    q_np = benjamini_hochberg(np.array(pvals))
+    q_series = benjamini_hochberg(pd.Series(pvals))
+    assert np.allclose(q_list, q_np)
+    assert np.allclose(q_list, q_series)
+
+
+def test_ties_stable():
+    # ties should be handled deterministically and give q >= p
+    pvals = [0.02, 0.02, 0.02, 0.5]
+    q = benjamini_hochberg(pvals)
+    assert np.all(q >= np.array(pvals) - 1e-12)
+    # the three equal small p's should share one q value
+    assert np.allclose(q[0], q[1]) and np.allclose(q[1], q[2])
+
+
+def test_cross_check_statsmodels_if_available():
+    statsmodels = pytest.importorskip("statsmodels")
+    from statsmodels.stats.multitest import multipletests
+    rng = np.random.default_rng(42)
+    pvals = rng.uniform(0, 1, size=137)
+    _, q_sm, _, _ = multipletests(pvals, method='fdr_bh')
+    q = benjamini_hochberg(pvals)
+    assert np.allclose(q, q_sm)
+
+
+# ---- lightweight integration check ----------------------------------------
+
+def test_q_columns_consistent_with_p_ordering():
+    # Independent BH computed over a p-column mirrors the q-column ordering:
+    # residues with smaller p must not have larger q.
+    rng = np.random.default_rng(7)
+    p = rng.uniform(0, 1, size=50)
+    # inject a couple of missing markers as the pipeline would
+    p_col = list(p)
+    p_col[3] = '-'
+    p_col[10] = np.nan
+    q = benjamini_hochberg(p_col)
+
+    valid = [i for i, v in enumerate(p_col)
+             if not (v == '-' or (isinstance(v, float) and np.isnan(v)))]
+    order = sorted(valid, key=lambda i: float(p_col[i]))
+    q_ordered = [q[i] for i in order]
+    # non-decreasing q along increasing p
+    assert all(q_ordered[k] <= q_ordered[k + 1] + 1e-12
+               for k in range(len(q_ordered) - 1))


### PR DESCRIPTION
## Problem
BE3D calls per-residue significance directly on the raw p-values (p<0.05/0.01/0.001) with no correction for the many residues tested simultaneously. In our benchmarking the fraction of residues flagged ("base rate") ranged from ~7% to ~50% across targets, so the raw p<0.05 flag over-calls and users are left ranking hits by hand. The standard fix is to report Benjamini-Hochberg (BH) FDR q-values.

## What changed
- Added a small, pure, numpy-only helper `benjamini_hochberg(pvals)` (BH step-up FDR) to `beclust3d/aggregate/aggregate_helpers.py`. NaN and the '-' missing-value marker are ignored in the correction and returned as NaN in place; ties use a stable sort. The result is monotone in sorted p and satisfies q >= p.
- `znorm_score` (`nonaggregate.py`) and `znorm_meta` (`metaaggregate.py`) now emit companion q-value columns `..._neg_q` and `..._pos_q`, computed from the p-values they already produce. Since the raw p-values do not depend on the p-value threshold, one q column per direction accompanies the threshold-indexed p columns.
- Docstrings note that a q-value threshold (e.g. q<0.1) is the recommended multiple-testing-aware call, and that base rates can otherwise be high.

This is strictly additive: all existing p-value and significance (`psig`) columns and their values are unchanged.

## How tested
`tests/test_fdr.py` (deterministic):
- Hand-computed BH q-values on known vectors (uniform-scaling example and a mixed, out-of-order example) via `allclose`.
- Monotonicity of the sorted q-values, q >= p, and cap at 1.
- NaN / '-' passthrough, all-missing, single-value, and stable-tie handling.
- Accepts list / numpy / pandas.Series inputs.
- Optional cross-check against `statsmodels` `multipletests(method='fdr_bh')` when importable (skips otherwise).
- A lightweight integration check that the q-column ordering is consistent with the p-column ordering.

Result in a clean venv (statsmodels not installed, so its cross-check is skipped):
```
9 passed, 1 skipped in 2.16s
```

## Backward compatibility
Fully backward compatible. Only new columns are added; no existing column, name, value, or return type changes. The new helper is standalone and numpy-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)